### PR TITLE
allow initialization from arguments instead of array

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -12,14 +12,26 @@ var Emitter = require('emitter'),
 
 module.exports = array;
 
+// used to check argument to constructor, etc.
+function isArray(obj) {
+    return ((obj && obj.isArray === '[object Array]') || 
+            (Object.prototype.toString.call(obj) === '[object Array]'));
+}
+
 /**
  * Initialize `array`
  */
 
-function array(arr) {
+function array() {
+  var arr = null;
+  if (arguments.length == 1 && isArray(arguments[0])) {
+    arr = arguments[0];
+  }
+  else {
+    arr = proto.slice.call(arguments);
+  }
   if(!(this instanceof array)) return new array(arr);
-  arr = arr || [];
-
+  
   // array-like
   var len = this.length = arr.length;
   for(var i = 0; i < len; i++) {


### PR DESCRIPTION
Can now simply say

var a = array(1,2,3)

in addition to still supporting

var a = array([1,2,3])

In the long run it probably makes sense to only support one of these initialization idioms, and I certainly don't mind if you reject this suggestion. I just thought I would mention it as an alternative.
