### PR TITLE
add ArrayLike.js marker for interop with other js libraries

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -40,6 +40,12 @@ Emitter(array.prototype);
 Enumerable(array.prototype);
 
 /**
+ * Add a marker for array object consumers to signal that Array methods are supported
+ * (see https://github.com/dribnet/ArrayLike.js)
+ */
+array.prototype.__ArrayLike = true;
+
+/**
  * Removes the last element from an array and returns that element
  *
  * @return {Mixed} removed element


### PR DESCRIPTION
Add a marker to make array compatible with other libraries
via either the ArrayLike polyfill or with libraries that
support the ArrayLike.js specification.

An example of this allowing interop with leaflet.js is here:

http://bl.ocks.org/dribnet/4326899

More information available here: 

https://github.com/dribnet/ArrayLike.js
