### PR TITLE
Use correct to-function dependency

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,7 +6,7 @@
   "keywords": [],
   "dependencies": {
     "component/emitter": "*",
-    "component/to-function": "getter/fns",
+    "component/to-function": "1.2.1",
     "yields/isArray": "1.0.0"
   },
   "development": {},

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "readmeFilename": "Readme.md",
   "dependencies": {
     "emitter-component": "~1.1.0",
-    "to-function": "~1.2.0"
+    "to-function": "~1.2.1"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "readmeFilename": "Readme.md",
   "dependencies": {
     "emitter-component": "~1.1.0",
-    "to-function": "~1.2.1"
+    "to-function": "~1.2.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Since the branch was merged (and probably deleted) upstream, I get the following error when installing:
Error: can't find remote for "component/to-function"
