### PR TITLE
Update dependencies to make it works with browserify and webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
     "enumerable"
   ],
   "browser": {
-    "emitter": "component-emitter",
-    "reactive": "component-reactive"
-  }
+    "reactive": "component-reactive",
+    "emitter": "component-emitter"
+  },
   "author": "matthew mueller",
   "license": "MIT",
   "readmeFilename": "Readme.md",
   "dependencies": {
-    "emitter-component": "~1.2.0",
-    "to-function": "~2.0.6"
+    "component-emitter": "^1.2.0",
+    "to-function": "^2.0.6"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "array",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "a vocal, functional array",
   "main": "array.js",
   "repository": {
@@ -13,12 +13,16 @@
     "vocal",
     "enumerable"
   ],
+  "browser": {
+    "emitter": "component-emitter",
+    "reactive": "component-reactive"
+  }
   "author": "matthew mueller",
   "license": "MIT",
   "readmeFilename": "Readme.md",
   "dependencies": {
-    "emitter-component": "~1.1.0",
-    "to-function": "~1.2.1"
+    "emitter-component": "~1.2.0",
+    "to-function": "~2.0.6"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Add browser field, so browserify and webpack would work.
Use component-emitter instead of emitter-component as later is out of date
Upgrade to-function as the old one not works with webpack & browserify
